### PR TITLE
Migration to independent project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,47 @@
+version: 2
+aliases:
+  # Re-usable job to run different types of builds.
+  - &job-build
+    working_directory: /app
+    docker:
+      - image: &builder-image integratedexperts/ci-builder
+        environment:
+          INSTALL_NEW_SITE: 1
+          LAGOON_ENVIRONMENT_TYPE: ci
+    steps:
+      - attach_workspace:
+          at: /workspace
+      - checkout
+      # Init environment for development.
+      - run: if [ -f "./dev-tools.sh" ] && [ ! "$DEV_TOOLS" ]; then ./dev-tools.sh; fi
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run: .circleci/build.sh
+      - run: .circleci/test.sh
+      - run:
+          name: Copy artifacts
+          command: .circleci/test-artifacts.sh
+          when: always
+      - store_artifacts:
+          path: /tmp/artifacts
+
+jobs:
+  build:
+    <<: *job-build
+
+  build_suggest:
+    <<: *job-build
+    docker:
+      - image: *builder-image
+        environment:
+          INSTALL_NEW_SITE: 1
+          LAGOON_ENVIRONMENT_TYPE: ci
+          INSTALL_SUGGEST: 1
+          BEHAT_PROFILE: "--profile=suggest"
+
+workflows:
+  version: 2
+  main:
+    jobs:
+      - build
+      - build_suggest

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Ignore files for distribution archives.
+.gitattributes            export-ignore
+.gitignore                export-ignore
+.github                   export-ignore
+.circleci                 export-ignore
+.circleci/config.yml      export-ignore
+.env                      export-ignore
+dev-init.sh               export-ignore

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # tide_event_atdw
 Import Events from Australian Tourism Data Warehouse.
 
+[![CircleCI](https://circleci.com/gh/dpc-sdp/tide_event_atdw.svg?style=svg&circle-token=b2c220627e28781bd41b4f830a21bd441957273c)](https://circleci.com/gh/dpc-sdp/tide_event_atdw)
+
 # CONTENTS OF THIS FILE
 * Introduction
 * Requirements
 * Usage
 
 # INTRODUCTION
-The Tide Event ATDW module provides the functionality to import events from 
+The Tide Event ATDW module provides the functionality to import events from
 Australian Tourism Data Warehouse.
 
 # REQUIREMENTS
@@ -39,7 +41,7 @@ drush migrate-reset-status tide_event_atdw_image
 drush migrate-reset-status tide_event_atdw_image_file
 ```
 
-* When running from Migrate Tools UI, the migrations must be executed in the 
+* When running from Migrate Tools UI, the migrations must be executed in the
 following order:
 
   1. tide_event_atdw_image_file

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_event": "^1.2.8",
+        "dpc-sdp/tide_event": "dev-feature/SDPA-2794_migrate_sdp-dpc_modules",
         "drupal/migrate_cron": "^1.2",
         "drupal/migrate_plus": "4.2",
         "drupal/migrate_tools": "^4.4",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0+",
     "version": "0.0.1",
     "require": {
-        "dpc-sdp/tide_event": "@dev",
+        "dpc-sdp/tide_event": "^1.2.8",
         "drupal/migrate_cron": "^1.2",
         "drupal/migrate_plus": "4.2",
         "drupal/migrate_tools": "^4.3",

--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,12 @@
     "name": "dpc-sdp/tide_event_atdw",
     "description": "Provides event importer from Australian Tourism Data Warehouse for Tide Drupal 8 distribution",
     "type": "drupal-module",
-    "license": "GPL-2.0+",
-    "version": "0.0.1",
+    "license": "GPL-2.0-or-later",
     "require": {
         "dpc-sdp/tide_event": "^1.2.8",
         "drupal/migrate_cron": "^1.2",
         "drupal/migrate_plus": "4.2",
-        "drupal/migrate_tools": "^4.3",
+        "drupal/migrate_tools": "^4.4",
         "drupal/migrate_file": "^1.1"
     },
     "repositories": {

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,6 @@
             },
             "drupal/migrate_cron": {
                 "Provide the ability to execute dependent migrations - https://www.drupal.org/project/migrate_cron/issues/3051619#comment-13087893": "https://www.drupal.org/files/issues/2019-04-30/3051619-migrate_cron-execute_dependencies-2.patch"
-            },
-            "drupal/migrate_tools": {
-                "status is not a log level - https://www.drupal.org/node/3073748": "https://www.drupal.org/files/issues/2019-08-09/3073748-migrate_tools-status_loglevel-2.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
+        "dpc-sdp/tide_core": "dev-feature/SDPA-2794_migrate_sdp-dpc_modules as 1.5.3",
         "dpc-sdp/tide_event": "dev-feature/SDPA-2794_migrate_sdp-dpc_modules",
         "drupal/migrate_cron": "^1.2",
         "drupal/migrate_plus": "4.2",

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_core": "dev-feature/SDPA-2794_migrate_sdp-dpc_modules as 1.5.3",
-        "dpc-sdp/tide_event": "dev-feature/SDPA-2794_migrate_sdp-dpc_modules",
+        "dpc-sdp/tide_core": "^1.5.4",
+        "dpc-sdp/tide_event": "^1.3.1",
         "drupal/migrate_cron": "^1.2",
         "drupal/migrate_plus": "4.2",
         "drupal/migrate_tools": "^4.4",

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+##
+# Install development files from the centralised location - Dev-Tools repository.
+#
+# === WHAT IS DEV-TOOLS ===
+# Dev-Tools is a development environment for Drupal sites with tools included.
+# https://github.com/dpc-sdp/dev-tools
+#
+# === WHAT IS THIS FILE AND WHY DO I NEED IT ===
+# Using Dev-Tools requires initial installation into your project. Once
+# installed, it the can be "attached" in every environment were development
+# stack is required. This means that your project will have only small number
+# of Dev-Tools files committed - the rest of the files will be downloaded each
+# time Dev-Tools needs to be "attached".
+#
+# This file is a script to download Dev-Tools at the latest stable version and
+# "attach" it to the current environment.
+# Files already committed within current repository will not be overridden.
+#
+# Usage:
+# ./dev-tools.sh
+#
+# === HOW TO OVERRIDE LOCALLY EXCLUDED FILES ===
+# To override any files coming from Dev-Tools to persist in the current
+# repository, modify `.git/info/exclude` file and commit them.
+#
+# === HOW TO UPDATE DEV-TOOLS ===
+# ALLOW_OVERRIDE=1 ./dev-tools.sh
+#
+# === HOW TO PIN TO SPECIFIC DEV-TOOLS COMMIT ===
+# For development of Dev-Tools or debugging of the development stack, it may be
+# required to point to the specific Dev-Tools's commit rather then use the latest
+# stable version.
+#
+# Uncomment and set the Dev-Tools's commit value and commit this change.
+# export GH_COMMIT=COMMIT_SHA
+
+bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-export GH_COMMIT=71205009208eb187156668dd9e2cdf2804d1d5a0
+export GH_COMMIT=895892cbeb51b0ef97b6a8f6728a25ea1214f174
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-export GH_COMMIT=81af0b8b2c337ea31d4a6b8e33f8501cdc3d97d3
+export GH_COMMIT=71205009208eb187156668dd9e2cdf2804d1d5a0
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-export GH_COMMIT=895892cbeb51b0ef97b6a8f6728a25ea1214f174
+# export GH_COMMIT=COMMIT_SHA
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-# export GH_COMMIT=COMMIT_SHA
+export GH_COMMIT=7c3669b2ddad2008ab29ed1fe3a247160d578083
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-export GH_COMMIT=7c3669b2ddad2008ab29ed1fe3a247160d578083
+export GH_COMMIT=81af0b8b2c337ea31d4a6b8e33f8501cdc3d97d3
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"


### PR DESCRIPTION
Moves tide_event_atdw from a project implementation to a independent module.

This hasn't been migrated to a sub-module of dpc-sdp/tide_event because the dependencies defined by this module would need to be installed by the parent and would add unnecessary bloat if not used. 

### Related PRs
dpc-sdp/content-vic-gov-au#724
dpc-sdp/tide#78
dpc-sdp/tide_core#102