### PR TITLE
removed unused patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,16 +18,5 @@
         }
     },
     "minimum-stability": "alpha",
-    "prefer-stable": true,
-    "extra": {
-        "enable-patching": true,
-        "patches": {
-            "drupal/migrate_plus": {
-                "Simple XML broken with UTF-16LE - https://www.drupal.org/project/migrate_plus/issues/3051858": "https://www.drupal.org/files/issues/2019-05-01/3051858-migrate_plus-simplexml_remove_trim-2.patch"
-            },
-            "drupal/migrate_cron": {
-                "Provide the ability to execute dependent migrations - https://www.drupal.org/project/migrate_cron/issues/3051619#comment-13087893": "https://www.drupal.org/files/issues/2019-04-30/3051619-migrate_cron-execute_dependencies-2.patch"
-            }
-        }
-    }
+    "prefer-stable": true
 }


### PR DESCRIPTION
### Motivation
1. we are removing tide_event_atdw from tide profile
### Changes
1. removed `Simple XML broken with UTF-16LE patch` as it is provided by tide_grant.
2. removed `Provide the ability to execute dependent migrations` as it is outdated.